### PR TITLE
add `SetStorage` methods to StateDB and StateObject

### DIFF
--- a/state_object.go
+++ b/state_object.go
@@ -203,6 +203,24 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 	s.setState(key, value)
 }
 
+// SetStorage replaces the entire state storage with the given one.
+//
+// After this function is called, all original state will be ignored and state
+// lookup only happens in the fake state storage.
+//
+// Note this function should only be used for debugging purpose.
+func (s *stateObject) SetStorage(storage map[common.Hash]common.Hash) {
+	// Allocate fake storage if it's nil.
+	if s.fakeStorage == nil {
+		s.fakeStorage = make(Storage)
+	}
+	for key, value := range storage {
+		s.fakeStorage[key] = value
+	}
+	// Don't bother journal since this function should only be used for
+	// debugging and the `fake` storage won't be committed to database.
+}
+
 func (s *stateObject) setState(key, value common.Hash) {
 	s.dirtyStorage[key] = value
 }

--- a/statedb.go
+++ b/statedb.go
@@ -277,6 +277,15 @@ func (s *StateDB) SetState(addr common.Address, key, value common.Hash) {
 	}
 }
 
+// SetStorage replaces the entire storage for the specified account with given
+// storage. This function should only be used for debugging.
+func (s *StateDB) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
+	stateObject := s.getOrNewStateObject(addr)
+	if stateObject != nil {
+		stateObject.SetStorage(storage)
+	}
+}
+
 // Suicide marks the given account as suicided.
 // This clears the account balance.
 //


### PR DESCRIPTION
These methods were originally omitted because they are not required to satisfy the `vm.StateDB` interface and are not used by the EVM at all, but during the integration into ipld-eth-server it was realized they are needed at a higher level of the`eth_call` code path: https://github.com/cerc-io/ipld-eth-server/blob/v4/pkg/eth/api.go#L1002.